### PR TITLE
Feat/cosmwasm@v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,31 +8,42 @@ The promise only applies to the main crate `smart-account-auth` (in packages/bun
 
 <!-- next-header -->
 
-
-## [0.28.0] - 2025-07-97
+## [0.28.0] - 2025-09-19
 
 ## Fixed
+
+- small spell check & readme QOL improvements
+
+## Changed
+
+- bumped cosmwasm-std & all relative cw crates to v3
+
+## [0.26.3] - 2025-07-97
+
+## Fixed
+
 - `CredentialWrapper` panicking on verify when calling `primary_id`
 - `CredentialWrapper`'s post validation not making sure that the sender is found when `use_native` is set
 
 ## Changed
+
 - `CredentialWrapper`'s method `with_native` now returns a copy of the data instead of changing in place
-
-
 
 ## [0.26.2] - 2025-07-97
 
 ## Added
+
 - Feature tags for including every single one of the supported credentials separately
 - `ClientData` of passkeys can now contain additional fields on top od the most common `other_keys_can...`
 - a separate testing golder
-- `InfoExtension` and `PayloadExtension` as a wrapper for current and all future supported extension tyoes 
-- [Feature] `cosmos_arb_addr` feature tag for a Cosmos Arbitrary with a passed address type instead of deriving it from prefix 
+- `InfoExtension` and `PayloadExtension` as a wrapper for current and all future supported extension tyoes
+- [Feature] `cosmos_arb_addr` feature tag for a Cosmos Arbitrary with a passed address type instead of deriving it from prefix
 - CheckOption and ReplayParams as argument to replay attack protection methods
 - `ReplayProtection` trait with methods for replay attack protection
 - Definitions to `EthTypedData` credential type
 
 ## Changed
+
 - `Verifiable` interface now has only one (mutually exclusive) `verify` method without VMs suffixes (like _cosmwasm)
 - `Verifiable` now return a `CredentialInfo` object instead
 - `CredentialInfo` now has an optional `address` for credentials that have them [`Caller`, `CosmosArbirary`]
@@ -46,22 +57,23 @@ The promise only applies to the main crate `smart-account-auth` (in packages/bun
 - [Feature] `ethereum` feature is changed to include all ethereum related credentials. The previous behaviour can enabled with `eth_personal` separately
 
 ## Fixed
+
 - Replay attack protection works for each credential individually now
 - Overall optimisations, refactoring and including less dependencies when possible
 - `PasskeyCredential` and `Secp256r1` are now in a separate crate and don't include `p256` crate for CosmWasm 2.0
 - `to_json_string` imports and definitions
 
 ## Removed
-- `injective` feature until adding complete support
 
+- `injective` feature until adding complete support
 
 ## [Unreleased] Typescript
 
 ## Changed
-- stopped converting `PasskeyCredential::credential_data.challenge` from `base64` to `base64-url` 
 
+- stopped converting `PasskeyCredential::credential_data.challenge` from `base64` to `base64-url`
 
-## [0.25.0] - 2024-12-18 
+## [0.25.0] - 2024-12-18
 
 ## Added
 
@@ -74,11 +86,12 @@ The promise only applies to the main crate `smart-account-auth` (in packages/bun
 - this document
 
 ## Changed
+
 - type of CredentialId has changed from `Vec<u8>` to `String`
-- response types that had ids were also changed from  `Binary` to `String` 
+- response types that had ids were also changed from  `Binary` to `String`
 - `Caller` credential is now an enum struct (after being a regular struct)
 - Minor changes to `ClientData` of `PasskeyCredential` related to optional key fields
-- renamed module with static storage variables from `storage` to `stores` 
+- renamed module with static storage variables from `storage` to `stores`
 - renamed `saa_type` to `saa_type` and added ability to omit exlusion of unknown properties by passing `no_deny`
 - split type macros into separate files for each type
 - `CredentialData`'s method was renamed to `with_native` and now inject the new caller from attached info only if the flag is set to `Some(true)` and return a miiror copy otherwise
@@ -86,13 +99,13 @@ The promise only applies to the main crate `smart-account-auth` (in packages/bun
 - updated readme with features and focus-areas
 
 ## Removed
+
 - All storage related types and primitives and logic have been removed to be moved to a separate package for each VM  
 - Deleted  `storage` and `iterator` feature tags
 
 ## Fixed
+
 - validation for max and min number of credentials in `CredentialData`
-- fixed situatino with redundant (re-)validations 
+- fixed situatino with redundant (re-)validations
 - removed clutter from complex derrive clauses
-- macros 
-
-
+- macros

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The promise only applies to the main crate `smart-account-auth` (in packages/bun
 <!-- next-header -->
 
 
-## [0.27.0] - 2025-07-97
+## [0.28.0] - 2025-07-97
 
 ## Fixed
 - `CredentialWrapper` panicking on verify when calling `primary_id`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The promise only applies to the main crate `smart-account-auth` (in packages/bun
 <!-- next-header -->
 
 
-## [0.26.3] - 2025-07-97
+## [0.27.0] - 2025-07-97
 
 ## Fixed
 - `CredentialWrapper` panicking on verify when calling `primary_id`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2235,7 +2235,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "saa-auth"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "hex",
  "primitive-types",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "saa-common"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.0",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "saa-crypto"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "bech32 0.11.0",
  "cosmwasm-crypto 3.0.2",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "saa-curves"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "saa-common",
  "saa-crypto",
@@ -2298,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "saa-passkeys"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "saa-common",
  "saa-crypto",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "saa-proto-core"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "saa-proto-solana"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "saa-proto-substrate"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "saa-proto-wasm"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "saa-schema"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "borsh",
  "cosmwasm-schema",
@@ -2363,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "saa-tests"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "base64-url",
  "cosmwasm-schema",
@@ -2832,7 +2832,7 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smart-account-auth"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "saa-auth",
  "saa-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,44 +62,14 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ark-bls12-381"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
-dependencies = [
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
-]
-
-[[package]]
-name = "ark-bls12-381"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
 dependencies = [
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
-]
-
-[[package]]
-name = "ark-ec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-poly 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "hashbrown 0.13.2",
- "itertools 0.10.5",
- "num-traits",
- "rayon",
- "zeroize",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
 ]
 
 [[package]]
@@ -109,10 +79,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
  "ahash 0.8.12",
- "ark-ff 0.5.0",
- "ark-poly 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.15.3",
@@ -126,35 +96,14 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
-dependencies = [
- "ark-ff-asm 0.4.2",
- "ark-ff-macros 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "digest 0.10.7",
- "itertools 0.10.5",
- "num-bigint",
- "num-traits",
- "paste",
- "rayon",
- "rustc_version",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
 dependencies = [
- "ark-ff-asm 0.5.0",
- "ark-ff-macros 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
  "arrayvec",
  "digest 0.10.7",
  "educe",
@@ -168,35 +117,12 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
-dependencies = [
- "num-bigint",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -214,42 +140,17 @@ dependencies = [
 
 [[package]]
 name = "ark-poly"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "ark-poly"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
  "ahash 0.8.12",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.15.3",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
-dependencies = [
- "ark-serialize-derive 0.4.2",
- "ark-std 0.4.0",
- "digest 0.10.7",
- "num-bigint",
 ]
 
 [[package]]
@@ -258,23 +159,12 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize-derive",
+ "ark-std",
  "arrayvec",
  "digest 0.10.7",
  "num-bigint",
  "rayon",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -286,17 +176,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
-dependencies = [
- "num-traits",
- "rand",
- "rayon",
 ]
 
 [[package]]
@@ -360,12 +239,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -384,12 +257,6 @@ name = "base64ct"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
-
-[[package]]
-name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bech32"
@@ -441,12 +308,6 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "bnum"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
 
 [[package]]
 name = "bnum"
@@ -576,52 +437,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b6dc17e7fd89d0a0a58f12ef33f0bbdf09a6a14c3dfb383eae665e5889250e"
-
-[[package]]
-name = "cosmwasm-core"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b0a718b13ffe224e32a8c1f68527354868f47d6cc84afe8c66cb05fbb3ced6e"
-
-[[package]]
-name = "cosmwasm-crypto"
-version = "1.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c82e56962f0f18c9a292aa59940e03a82ce15ef79b93679d5838bb8143f0df"
-dependencies = [
- "digest 0.10.7",
- "ed25519-zebra 3.1.0",
- "k256 0.13.4",
- "rand_core 0.6.4",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cosmwasm-crypto"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2f53285517db3e33d825b3e46301efe845135778527e1295154413b2f0469e"
-dependencies = [
- "ark-bls12-381 0.4.0",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "cosmwasm-core 2.2.2",
- "curve25519-dalek 4.1.3",
- "digest 0.10.7",
- "ecdsa 0.16.9",
- "ed25519-zebra 4.0.3",
- "k256 0.13.4",
- "num-traits",
- "p256",
- "rand_core 0.6.4",
- "rayon",
- "sha2 0.10.9",
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "cosmwasm-crypto"
@@ -629,11 +447,11 @@ version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c08dd7585b5c48fbcb947ada7a3fb49465fb735481ed295b54ca98add6dc17f"
 dependencies = [
- "ark-bls12-381 0.5.0",
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "cosmwasm-core 3.0.2",
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "cosmwasm-core",
  "curve25519-dalek 4.1.3",
  "digest 0.10.7",
  "ecdsa 0.16.9",
@@ -659,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "2.2.2"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a782b93fae93e57ca8ad3e9e994e784583f5933aeaaa5c80a545c4b437be2047"
+checksum = "5677eed823a61eeb615b1ad4915a42336b70b0fe3f87bf3da4b59f3dcf9034af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -695,45 +513,24 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.5.11"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763340055b84e5482ed90fec8194ff7d59112267a09bbf5819c9e3edca8c052e"
-dependencies = [
- "base64 0.21.7",
- "bech32 0.9.1",
- "bnum 0.10.0",
- "cosmwasm-crypto 1.5.11",
- "cosmwasm-derive 1.5.11",
- "derivative",
- "forward_ref",
- "hex",
- "schemars 0.8.22",
- "serde",
- "serde-json-wasm 0.5.2",
- "sha2 0.10.9",
- "static_assertions",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cosmwasm-std"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf82335c14bd94eeb4d3c461b7aa419ecd7ea13c2efe24b97cd972bdb8044e7d"
+checksum = "d4881104f54871bcea6f30757bee13b7f09c0998d1b0de133cce5a52336a2ada"
 dependencies = [
  "base64 0.22.1",
- "bech32 0.11.0",
- "bnum 0.11.0",
- "cosmwasm-core 2.2.2",
- "cosmwasm-crypto 2.2.2",
- "cosmwasm-derive 2.2.2",
- "derive_more 1.0.0",
+ "bech32",
+ "bnum",
+ "cosmwasm-core",
+ "cosmwasm-crypto",
+ "cosmwasm-derive 3.0.2",
+ "cw-schema",
+ "derive_more 2.0.1",
  "hex",
  "rand_core 0.6.4",
  "rmp-serde",
  "schemars 0.8.22",
  "serde",
- "serde-json-wasm 1.0.1",
+ "serde_json",
  "sha2 0.10.9",
  "static_assertions",
  "thiserror 1.0.69",
@@ -1012,7 +809,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl 2.0.1",
 ]
 
 [[package]]
@@ -1020,6 +826,18 @@ name = "derive_more-impl"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1356,15 +1174,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.12",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1684,15 +1493,6 @@ checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -1736,9 +1536,7 @@ dependencies = [
  "cfg-if",
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
- "once_cell",
  "sha2 0.10.9",
- "signature 2.2.0",
 ]
 
 [[package]]
@@ -2252,11 +2050,10 @@ name = "saa-common"
 version = "0.28.0"
 dependencies = [
  "base64 0.22.1",
- "bech32 0.11.0",
+ "bech32",
  "borsh",
- "cosmwasm-crypto 3.0.2",
- "cosmwasm-std 1.5.11",
- "cosmwasm-std 2.2.2",
+ "cosmwasm-crypto",
+ "cosmwasm-std",
  "getrandom",
  "ink",
  "parity-scale-codec",
@@ -2275,8 +2072,8 @@ dependencies = [
 name = "saa-crypto"
 version = "0.28.0"
 dependencies = [
- "bech32 0.11.0",
- "cosmwasm-crypto 3.0.2",
+ "bech32",
+ "cosmwasm-crypto",
  "digest 0.10.7",
  "p256",
  "ripemd",
@@ -2367,7 +2164,7 @@ version = "0.28.0"
 dependencies = [
  "base64-url",
  "cosmwasm-schema",
- "cosmwasm-std 2.2.2",
+ "cosmwasm-std",
  "hex",
  "saa-common",
  "saa-schema",
@@ -2661,15 +2458,6 @@ name = "serde-json-wasm"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479b4dbc401ca13ee8ce902851b834893251404c4f3c65370a49e047a6be09a5"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde-json-wasm"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9213a07d53faa0b8dd81e767a54a8188a242fdb9be99ab75ec576a774bfdd7"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,10 +66,22 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -78,13 +90,35 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-poly 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
+ "num-traits",
+ "rayon",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash 0.8.12",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.3",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
  "num-traits",
  "rayon",
  "zeroize",
@@ -96,10 +130,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
@@ -112,6 +146,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rayon",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +174,16 @@ checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -135,16 +200,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "ark-poly"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash 0.8.12",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -153,10 +246,24 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive",
- "ark-std",
+ "ark-serialize-derive 0.4.2",
+ "ark-std 0.4.0",
  "digest 0.10.7",
  "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-serialize-derive 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+ "rayon",
 ]
 
 [[package]]
@@ -171,10 +278,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
+ "rayon",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
  "rand",
@@ -452,6 +581,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35b6dc17e7fd89d0a0a58f12ef33f0bbdf09a6a14c3dfb383eae665e5889250e"
 
 [[package]]
+name = "cosmwasm-core"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b0a718b13ffe224e32a8c1f68527354868f47d6cc84afe8c66cb05fbb3ced6e"
+
+[[package]]
 name = "cosmwasm-crypto"
 version = "1.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,16 +605,41 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa2f53285517db3e33d825b3e46301efe845135778527e1295154413b2f0469e"
 dependencies = [
- "ark-bls12-381",
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "cosmwasm-core",
+ "ark-bls12-381 0.4.0",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "cosmwasm-core 2.2.2",
  "curve25519-dalek 4.1.3",
  "digest 0.10.7",
  "ecdsa 0.16.9",
  "ed25519-zebra 4.0.3",
  "k256 0.13.4",
+ "num-traits",
+ "p256",
+ "rand_core 0.6.4",
+ "rayon",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cosmwasm-crypto"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c08dd7585b5c48fbcb947ada7a3fb49465fb735481ed295b54ca98add6dc17f"
+dependencies = [
+ "ark-bls12-381 0.5.0",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "cosmwasm-core 3.0.2",
+ "curve25519-dalek 4.1.3",
+ "digest 0.10.7",
+ "ecdsa 0.16.9",
+ "ed25519-zebra 4.0.3",
+ "k256 0.13.4",
+ "num-bigint",
  "num-traits",
  "p256",
  "rand_core 0.6.4",
@@ -510,12 +670,13 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.5.11"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5526ea839acb47bbf8fff031ed9aad86e74d43f77b089255417328c3664367d5"
+checksum = "52d8808bf9fb8f4d5ee62e808b3e1dcdf6a116e9e1fe934507a4e0a4135ae941"
 dependencies = [
  "cosmwasm-schema-derive",
- "schemars",
+ "cw-schema",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -523,13 +684,13 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.5.11"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f41b99f41f840765d02ae858956bb52af910755976312082e90493c67db512"
+checksum = "9718a856ff5edb6537ac889ff695abc576304bc25cb7b16ef4c762e10a0149ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -546,7 +707,7 @@ dependencies = [
  "derivative",
  "forward_ref",
  "hex",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde-json-wasm 0.5.2",
  "sha2 0.10.9",
@@ -563,14 +724,14 @@ dependencies = [
  "base64 0.22.1",
  "bech32 0.11.0",
  "bnum 0.11.0",
- "cosmwasm-core",
+ "cosmwasm-core 2.2.2",
  "cosmwasm-crypto 2.2.2",
  "cosmwasm-derive 2.2.2",
  "derive_more 1.0.0",
  "hex",
  "rand_core 0.6.4",
  "rmp-serde",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde-json-wasm 1.0.1",
  "sha2 0.10.9",
@@ -694,13 +855,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-schema"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f335d3f51e10260f4dfb0840f0526c1d25c6b42a9489c04ce41ed9aa54dd6d"
+dependencies = [
+ "cw-schema-derive",
+ "indexmap",
+ "schemars 1.0.4",
+ "serde",
+ "serde_with",
+ "siphasher",
+ "typeid",
+]
+
+[[package]]
+name = "cw-schema-derive"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba2eb93f854caeacc5eda13d15663b7605395514fd378bfba8e7532f1fc5865"
+dependencies = [
+ "heck",
+ "itertools 0.13.0",
+ "owo-colors",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
 ]
 
 [[package]]
@@ -713,8 +913,22 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -723,9 +937,20 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -922,6 +1147,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,6 +1201,26 @@ dependencies = [
  "sec1 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1121,12 +1378,21 @@ name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1330,7 +1596,7 @@ dependencies = [
  "linkme",
  "parity-scale-codec",
  "scale-info",
- "schemars",
+ "schemars 0.8.22",
  "serde",
 ]
 
@@ -1400,6 +1666,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,6 +1696,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1553,6 +1845,16 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
+dependencies = [
+ "supports-color 2.1.0",
+ "supports-color 3.0.2",
+]
 
 [[package]]
 name = "p256"
@@ -1798,6 +2100,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,26 +2235,26 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "saa-auth"
-version = "0.26.9"
+version = "0.27.0"
 dependencies = [
  "hex",
  "primitive-types",
  "saa-common",
  "saa-crypto",
  "saa-schema",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde-cw-value",
 ]
 
 [[package]]
 name = "saa-common"
-version = "0.26.9"
+version = "0.27.0"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.0",
  "borsh",
- "cosmwasm-crypto 2.2.2",
+ "cosmwasm-crypto 3.0.2",
  "cosmwasm-std 1.5.11",
  "cosmwasm-std 2.2.2",
  "getrandom",
@@ -1940,7 +2262,7 @@ dependencies = [
  "parity-scale-codec",
  "saa-schema",
  "scale-info",
- "schemars",
+ "schemars 0.8.22",
  "secret-cosmwasm-std",
  "serde",
  "serde-cw-value",
@@ -1951,10 +2273,10 @@ dependencies = [
 
 [[package]]
 name = "saa-crypto"
-version = "0.26.9"
+version = "0.27.0"
 dependencies = [
  "bech32 0.11.0",
- "cosmwasm-crypto 2.2.2",
+ "cosmwasm-crypto 3.0.2",
  "digest 0.10.7",
  "p256",
  "ripemd",
@@ -1967,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "saa-curves"
-version = "0.26.9"
+version = "0.27.0"
 dependencies = [
  "saa-common",
  "saa-crypto",
@@ -1976,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "saa-passkeys"
-version = "0.26.9"
+version = "0.27.0"
 dependencies = [
  "saa-common",
  "saa-crypto",
@@ -1986,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "saa-proto-core"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1995,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "saa-proto-solana"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2004,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "saa-proto-substrate"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2013,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "saa-proto-wasm"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2022,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "saa-schema"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "borsh",
  "cosmwasm-schema",
@@ -2032,7 +2354,7 @@ dependencies = [
  "saa-proto-substrate",
  "saa-proto-wasm",
  "scale-info",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "strum",
  "strum_macros",
@@ -2041,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "saa-tests"
-version = "0.26.9"
+version = "0.27.0"
 dependencies = [
  "base64-url",
  "cosmwasm-schema",
@@ -2049,7 +2371,7 @@ dependencies = [
  "hex",
  "saa-common",
  "saa-schema",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "smart-account-auth",
@@ -2096,7 +2418,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5398fdb3c7bea3cb419bac4983aadacae93fe1a7b5f693f4ebd98c3821aad7a5"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2121,7 +2443,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a304e1af7cdfbe7a24e08b012721456cc8cecdedadc14b3d10513eada63233c"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
@@ -2139,7 +2461,7 @@ dependencies = [
  "derive_more 1.0.0",
  "parity-scale-codec",
  "scale-info-derive",
- "schemars",
+ "schemars 0.8.22",
  "serde",
 ]
 
@@ -2171,7 +2493,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
- "schemars_derive",
+ "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive 1.0.4",
  "serde",
  "serde_json",
 ]
@@ -2181,6 +2516,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2277,7 +2624,7 @@ dependencies = [
  "derivative",
  "forward_ref",
  "hex",
- "schemars",
+ "schemars 0.8.22",
  "secret-cosmwasm-crypto",
  "serde",
  "serde-json-wasm 0.4.1",
@@ -2389,6 +2736,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,6 +2819,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,7 +2832,7 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smart-account-auth"
-version = "0.26.3"
+version = "0.27.0"
 dependencies = [
  "saa-auth",
  "saa-common",
@@ -2464,7 +2840,7 @@ dependencies = [
  "saa-curves",
  "saa-passkeys",
  "saa-schema",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde-cw-value",
  "strum",
@@ -2563,6 +2939,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2586,6 +2968,25 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
 
 [[package]]
 name = "syn"
@@ -2735,6 +3136,12 @@ name = "toml_write"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version         = "0.26.9"
+version         = "0.27.0"
 edition         = "2021"
 readme          = "README.md"
 repository      = "https://github.com/MegaRockLabs/smart-account-auth"
@@ -31,22 +31,22 @@ bech32                  = { version = "0.11.0", default-features = false, featur
 base64                  = { version = "0.22.1", default-features = false, features = ["alloc"] }
 semver                  = { version = "1.0.26", default-features = false }
 thiserror               = { version = "2.0.12", default-features = false }
-cosmwasm-schema         = { version = "1.5.11", default-features = false }
-cosmwasm-crypto         = { version = "2.2.2",  default-features = false }
+cosmwasm-schema         = { version = "3.0.2", default-features = false }
+cosmwasm-crypto         = { version = "3.0.2",  default-features = false }
 
 
-saa-proto-core          = { version = "0.26.0", path = "packages/macros-proto/core" }
-saa-proto-wasm          = { version = "0.26.0", path = "packages/macros-proto/wasm" }
-saa-proto-solana        = { version = "0.26.0", path = "packages/macros-proto/solana" }
-saa-proto-substrate     = { version = "0.26.0", path = "packages/macros-proto/substrate" }
+saa-proto-core          = { version = "0.27.0", path = "packages/macros-proto/core" }
+saa-proto-wasm          = { version = "0.27.0", path = "packages/macros-proto/wasm" }
+saa-proto-solana        = { version = "0.27.0", path = "packages/macros-proto/solana" }
+saa-proto-substrate     = { version = "0.27.0", path = "packages/macros-proto/substrate" }
 
-saa-schema              = { version = "0.26.0", path = "packages/schema" }
-saa-common              = { version = "0.26.8", path = "packages/common", default-features = false }
-saa-crypto              = { version = "0.26.7", path = "packages/crypto" }
-saa-auth                = { version = "0.26.8", path = "packages/auth" }
-saa-curves              = { version = "0.26.5", path = "packages/curves" }
-saa-passkeys            = { version = "0.26.5", path = "packages/passkeys" }
-smart-account-auth      = { version = "0.26.3", path = "packages/bundle", default-features = false }
+saa-schema              = { version = "0.27.0", path = "packages/schema" }
+saa-common              = { version = "0.27.0", path = "packages/common", default-features = false }
+saa-crypto              = { version = "0.27.0", path = "packages/crypto" }
+saa-auth                = { version = "0.27.0", path = "packages/auth" }
+saa-curves              = { version = "0.27.0", path = "packages/curves" }
+saa-passkeys            = { version = "0.27.0", path = "packages/passkeys" }
+smart-account-auth      = { version = "0.27.0", path = "packages/bundle", default-features = false }
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version         = "0.27.0"
+version         = "0.28.0"
 edition         = "2021"
 readme          = "README.md"
 repository      = "https://github.com/MegaRockLabs/smart-account-auth"
@@ -35,18 +35,18 @@ cosmwasm-schema         = { version = "3.0.2", default-features = false }
 cosmwasm-crypto         = { version = "3.0.2",  default-features = false }
 
 
-saa-proto-core          = { version = "0.27.0", path = "packages/macros-proto/core" }
-saa-proto-wasm          = { version = "0.27.0", path = "packages/macros-proto/wasm" }
-saa-proto-solana        = { version = "0.27.0", path = "packages/macros-proto/solana" }
-saa-proto-substrate     = { version = "0.27.0", path = "packages/macros-proto/substrate" }
+saa-proto-core          = { version = "0.28.0", path = "packages/macros-proto/core" }
+saa-proto-wasm          = { version = "0.28.0", path = "packages/macros-proto/wasm" }
+saa-proto-solana        = { version = "0.28.0", path = "packages/macros-proto/solana" }
+saa-proto-substrate     = { version = "0.28.0", path = "packages/macros-proto/substrate" }
 
-saa-schema              = { version = "0.27.0", path = "packages/schema" }
-saa-common              = { version = "0.27.0", path = "packages/common", default-features = false }
-saa-crypto              = { version = "0.27.0", path = "packages/crypto" }
-saa-auth                = { version = "0.27.0", path = "packages/auth" }
-saa-curves              = { version = "0.27.0", path = "packages/curves" }
-saa-passkeys            = { version = "0.27.0", path = "packages/passkeys" }
-smart-account-auth      = { version = "0.27.0", path = "packages/bundle", default-features = false }
+saa-schema              = { version = "0.28.0", path = "packages/schema" }
+saa-common              = { version = "0.28.0", path = "packages/common", default-features = false }
+saa-crypto              = { version = "0.28.0", path = "packages/crypto" }
+saa-auth                = { version = "0.28.0", path = "packages/auth" }
+saa-curves              = { version = "0.28.0", path = "packages/curves" }
+saa-passkeys            = { version = "0.28.0", path = "packages/passkeys" }
+smart-account-auth      = { version = "0.28.0", path = "packages/bundle", default-features = false }
 
 
 

--- a/README.md
+++ b/README.md
@@ -31,18 +31,26 @@ Authentication Library / SDK  for working with various crypthograpghic credentia
 
 ## Supported Credentials
 
-- Ethereum (EVM) personal sign
-- Cosmos Arbitrary (036)
-- Passkeys / Webauthn
-- Secp256k1 / Secp256r1 / Ed25519 Curves
+| Credential               | Feature Flag     | Specification / Use Case                          |
+|--------------------------|------------------|----------------------------------------------------|
+| Ethereum Personal Sign   | ``ethereum``     | EVM-compatible signing (EIP-191)                  |
+| Cosmos Arbitrary Sign    | ``cosmos``       | Human-readable msgs (ADR-036)                     |
+| Passkeys (WebAuthn)      | ``passkeys``     | FIDO2 / WebAuthn public key authentication        |
+| Secp256k1 / Secp256r1    | ``curves`` or ``ethereum`` | Raw signature verification on ECDSA curves |
+| Ed25519                  | ``curves`` or ``ed25519`` | EdDSA signatures (e.g., Solana, Substrate)   |
+
 
 ## Virtual Machine Support
 
-- Cosmwasm [1.x]  -  Complete
-- Cosmwasm [2.x]  -  Partial
-- SecretWasm      -  Partial
-- Ink / Substrate -  Partial
-- Solana Seahorse -  Serialization
+| Virtual Machine       | Version      | Support Level     | Notes                                  |
+|-----------------------|-------------|-------------------|----------------------------------------|
+| CosmWasm              | 1.x         | Complete          | Full signing and verification          |
+| CosmWasm              | 2.x         | Partial           | Ongoing updates for v2 changes         |
+| SecretWasm            | -           | Partial           | Based on CosmWasm; limited extensions  |
+| Ink / Substrate       | -           | Partial           | Core types supported; more in development |
+| Solana (Seahorse)     | -           | Serialization     | Only message serialization; no signing |
+
+> Legend: Complete = fully supported, Partial = limited or experimental, Serialization = only data formatting available
 
 # Smart Contracts / Programs
 
@@ -62,38 +70,52 @@ saa  = { package = "smart-account-auth", version = "0.24.5", features = ["cosmwa
 
 ### Features
 
-Environment specific features that are mutually exclusive and shouldn't be used together. Pick depending on your virtual machine
+Environment specific features that are mutually exclusive and **shouldn't** be used together. Pick depending on your virtual machine:
 
-- `native` - for native rust code
-- `cosmwasm` - for cosmwasm 2.x
-- `cosmwasm_v1` - for cosmwasm 1.x
-- `secretwasm` - for cosmwasm of secret network (in development)
-- `substrate` - for smart contracts written in ink (in development)
-- `solana` - for solana programs (in development)
+| Feature         | Target Environment                     | Status        |
+|----------------|----------------------------------------|---------------|
+| ``native``     | Native Rust execution                  | Stable        |
+| ``cosmwasm``   | CosmWasm 2.x smart contracts           | Stable        |
+| ``cosmwasm_v1``| CosmWasm 1.x smart contracts           | Stable        |
+| ``secretwasm`` | Secret Network (CosmWasm fork)         | In Development |
+| ``substrate``  | Substrate ink! smart contracts         | In Development |
+| ``solana``     | Solana programs (BPF)                  | In Development |
 
-Credential specifc features allow you to include / exclude specific credential types for better control and optimisizing the binary size
+Credential specifc features allow you to include / exclude specific credential types for better control and optimisizing the binary size:
 
-- `ethereum` - for Ethereum personal sign message specification (  [EIP-191](https://eips.ethereum.org/EIPS/eip-191) )
-- `cosmos` - for Cosmos Arbitrary message specificion (  [ADR 036](https://github.com/cosmos/cosmos-sdk/blob/main/docs/architecture/adr-036-arbitrary-signature.md) )
-- `passkeys` - for passkey based authentication ( [Webauthn](https://www.w3.org/TR/webauthn-3) )
-- `curves` - verification of signature over any raw data using any of the supported curves (Ed25519, Secp256k1, Secp256r1)
-- `ed25519` - same as above but only for Ed25519 curve
+| Feature       | Purpose                                      | Specification |
+|--------------|----------------------------------------------|---------------|
+| ``ethereum`` | Ethereum personal sign messages              | [EIP-191](https://eips.ethereum.org/EIPS/eip-191) |
+| ``cosmos``   | Cosmos arbitrary signing (human-readable)    | [ADR-036](https://github.com/cosmos/cosmos-sdk/blob/main/docs/architecture/adr-036-arbitrary-signature.md) |
+| ``passkeys`` | WebAuthn / FIDO2 passkey authentication      | [WebAuthn](https://www.w3.org/TR/webauthn-3) |
+| ``curves``   | Raw data sig verification (Ed25519, Secp256k1, Secp256r1) | Multi-curve support |
+| ``ed25519``  | Sig verification only on Ed25519 curve       | Subset of ``curves`` |
 
 The following features give you access to additional logic related to better control or additional security
 
-- `session` - tool and primitives for session keys and message type identification
-- `replay` - enable replay protection and enforce signed messages to follow a specific format that includes nonces
-- `std` - whether to enable native Rust std library
+| Feature     | Purpose                                      |
+|------------|----------------------------------------------|
+| ``session``| Tools & primitives for  session keys and message typing      |
+| ``replay`` | Adds replay protection with nonce enforcement |
+| ``std``    | Enables Rust `std` (vs `no_std` compatibility) |
+
 
 The following features enable or disable inner primitives to ether help you out or to reduce the binary size as much as possible
 
-- `utils` - inner utilities for serialization and preparing them for cryptography
-- `types` - enable minimalistic vm agnostic types ported from `cosmwasm_std` and `cw-utils`
-- `traits` - for importing trait `Verifiable` used internally or `CredentialsWrapper` to customise or simply use the wrapper methods
+| Feature      | Purpose                                         |
+|-------------|-------------------------------------------------|
+| ``utils``   | Serialization and crypto preprocessing tools   |
+| ``types``   | Lightweight, VM-agnostic types (from `cosmwasm_std` / `cw-utils`) |
+| ``traits``  | Exposes `Verifiable` *used internally* and `CredentialsWrapper` traits *to customise or simply use the wrapper methods* |
+
+___
 
 The following credentials are not meant to be specified directly and used only internal purposes 🚫
 
-- `wasm` - common logic for different versions of cosmwasm or it's derivatives
+| Feature   | Purpose                              |
+|----------|---------------------------------------|
+| ``wasm`` | Shared logic for CosmWasm derivatives |
+
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Authentication Library / SDK  for working with various crypthograpghic credentia
 | Secp256k1 / Secp256r1    | ``curves`` or ``ethereum`` | Raw signature verification on ECDSA curves |
 | Ed25519                  | ``curves`` or ``ed25519`` | EdDSA signatures (e.g., Solana, Substrate)   |
 
-
 ## Virtual Machine Support
 
 | Virtual Machine       | Version      | Support Level     | Notes                                  |
@@ -99,7 +98,6 @@ The following features give you access to additional logic related to better con
 | ``replay`` | Adds replay protection with nonce enforcement |
 | ``std``    | Enables Rust `std` (vs `no_std` compatibility) |
 
-
 The following features enable or disable inner primitives to ether help you out or to reduce the binary size as much as possible
 
 | Feature      | Purpose                                         |
@@ -115,7 +113,6 @@ The following credentials are not meant to be specified directly and used only i
 | Feature   | Purpose                              |
 |----------|---------------------------------------|
 | ``wasm`` | Shared logic for CosmWasm derivatives |
-
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 # Smart Account Authentication
 
-Authentication Library / SDK  for working with various crypthograpghic credentials / authenticators
+Authentication Library / SDK  for working with various cryptographic credentials / authenticators
 
-- Client-side tools for requesting credentials abd their serilizations
+- Client-side tools for requesting credentials and their serializations
 - Verification (+ storage) logic for Rust environments.
 - Ideal for smart accounts, wallets and apps with build-in authentication
 
@@ -15,19 +15,19 @@ Authentication Library / SDK  for working with various crypthograpghic credentia
 - Formatting data according to specs. Primarily with use of envelopes
 - Serialisation and deserialisation of the date depending on context
 - Passing data to underlying cryptographic APIs and libraries
-- Dealing with batches / multuple credentials at the same time
+- Dealing with batches / multiple credentials at the same time
 - [FEAT] Protection against replay attacks
 - [FEAT] Encapsulated storage of the credentials
 - [FEAT] Encapsulated reconstruction & verification of credentials from payload
 
 ### Cryptography
 
-- ⚡ Delegations verifcation to available APIs for efficency
+- ⚡ Delegations verification to available APIs for efficiency
 - ⚙️ Native version relies on [cosmwasm-crypto](https://crates.io/crates/cosmwasm-crypto)
 
 ### Other Info
 
-- **Encoding:** By default using `base64` everywhere. The exceptions are primarily when it makes sence according to the specs of a credential such as Eth addresses using `hex` or webauthn challenge using `base64url`
+- **Encoding:** By default using `base64` everywhere. The exceptions are primarily when it makes sense according to the specs of a credential such as Eth addresses using `hex` or webauthn challenge using `base64url`
 
 ## Supported Credentials
 
@@ -53,7 +53,7 @@ Authentication Library / SDK  for working with various crypthograpghic credentia
 
 # Smart Contracts / Programs
 
-## Instalation
+## Installation
 
 ```bash
 # Add the library to your project
@@ -63,7 +63,7 @@ cargo add smart-account-auth
 You can also give the library an alias to simplify typing
 
 ```toml
-# tp import for CosmWasm(v1) contracts with all default features 
+# to import for CosmWasm(v1) contracts with all default features 
 saa  = { package = "smart-account-auth", version = "0.24.5", features = ["cosmwasm"] }
 ```
 
@@ -80,7 +80,7 @@ Environment specific features that are mutually exclusive and **shouldn't** be u
 | ``substrate``  | Substrate ink! smart contracts         | In Development |
 | ``solana``     | Solana programs (BPF)                  | In Development |
 
-Credential specifc features allow you to include / exclude specific credential types for better control and optimisizing the binary size:
+Credential specific features allow you to include / exclude specific credential types for better control and optimizing the binary size:
 
 | Feature       | Purpose                                      | Specification |
 |--------------|----------------------------------------------|---------------|
@@ -182,7 +182,7 @@ npm install smart-account-auth
 
 ### Basics
 
-Requsting a credemtial is as simple as calling a function with a message to be signed and passing the neccecary signer information
+Requesting a credential is as simple as calling a function with a message to be signed and passing the neccecary signer information
 
 ```typescript
 import { getEthPersonalSignCredential } from 'smart-account-auth';
@@ -221,7 +221,7 @@ const credential = await getPasskeyCredPromise;
 
 ### Replay Attack Protection
 
-If replay attack protection is enabled on the contract side, the message to be signed must be a json strong of the following format
+If replay attack protection is enabled on the contract side, the message to be signed must be a json string of the following format
 
 ```typescript
 type DataToSign = {
@@ -254,7 +254,7 @@ const data : CredentialData = {
 ### Meta / Usage
 
 - OpenSource -> Low Funding / Resources -> Contributions are especially needed and welcomed
-- Authors of the library are also its main users. The expirience is iteratively used to improve the SDK by understaning the needs and shifting more and more logic from apps to the lib.
+- Authors of the library are also its main users. The experience is iteratively used to improve the SDK by understanding the needs and shifting more and more logic from apps to the lib.
 - `CosmWasm` retains the status of the primary target and used the most often during feature design stage and for tests. The main reason is being funded through quadrating funding on [DoraHacks](https://dorahacks.io/aez).
 
 ## Disclaimer

--- a/README.md
+++ b/README.md
@@ -4,47 +4,47 @@
 # Smart Account Authentication
 
 Authentication Library / SDK  for working with various crypthograpghic credentials / authenticators
-- Client-side tools for requesting credentials abd their serilizations 
-- Verification (+ storage) logic for Rust environments. 
-- Ideal for smart accounts, wallets and apps with build-in authentication 
+
+- Client-side tools for requesting credentials abd their serilizations
+- Verification (+ storage) logic for Rust environments.
+- Ideal for smart accounts, wallets and apps with build-in authentication
 
 ## Goals and Focus-Area
+
 - Definition of useful data structure, trais and utlity functions
 - Formatting data according to specs. Primarily with use of envelopes
 - Serialisation and deserialisation of the date depending on context
 - Passing data to underlying cryptographic APIs and libraries
-- Dealing with batches / multuple credentials at the same time 
-- [FEAT] Protection against replay attacks 
-- [FEAT] Encapsulated storage of the credentials 
+- Dealing with batches / multuple credentials at the same time
+- [FEAT] Protection against replay attacks
+- [FEAT] Encapsulated storage of the credentials
 - [FEAT] Encapsulated reconstruction & verification of credentials from payload
 
 ### Cryptography
-- ⚡ Delegations verifcation to available APIs for efficency 
+
+- ⚡ Delegations verifcation to available APIs for efficency
 - ⚙️ Native version relies on [cosmwasm-crypto](https://crates.io/crates/cosmwasm-crypto)
 
 ### Other Info
 
-- **Encoding:** By default using `base64` everywhere. The exceptions are primarily when it makes sence according to the specs of a credential such as Eth addresses using `hex` or webauthn challenge using `base64url` 
-
-
+- **Encoding:** By default using `base64` everywhere. The exceptions are primarily when it makes sence according to the specs of a credential such as Eth addresses using `hex` or webauthn challenge using `base64url`
 
 ## Supported Credentials
+
 - Ethereum (EVM) personal sign
 - Cosmos Arbitrary (036)
 - Passkeys / Webauthn
 - Secp256k1 / Secp256r1 / Ed25519 Curves
 
 ## Virtual Machine Support
+
 - Cosmwasm [1.x]  -  Complete
 - Cosmwasm [2.x]  -  Partial
 - SecretWasm      -  Partial
 - Ink / Substrate -  Partial
 - Solana Seahorse -  Serialization
 
-
-
 # Smart Contracts / Programs
-
 
 ## Instalation
 
@@ -54,6 +54,7 @@ cargo add smart-account-auth
 ```
 
 You can also give the library an alias to simplify typing
+
 ```toml
 # tp import for CosmWasm(v1) contracts with all default features 
 saa  = { package = "smart-account-auth", version = "0.24.5", features = ["cosmwasm"] }
@@ -62,40 +63,42 @@ saa  = { package = "smart-account-auth", version = "0.24.5", features = ["cosmwa
 ### Features
 
 Environment specific features that are mutually exclusive and shouldn't be used together. Pick depending on your virtual machine
+
 - `native` - for native rust code
 - `cosmwasm` - for cosmwasm 2.x
-- `cosmwasm_v1` - for cosmwasm 1.x 
+- `cosmwasm_v1` - for cosmwasm 1.x
 - `secretwasm` - for cosmwasm of secret network (in development)
 - `substrate` - for smart contracts written in ink (in development)
 - `solana` - for solana programs (in development)
-
 
 Credential specifc features allow you to include / exclude specific credential types for better control and optimisizing the binary size
 
 - `ethereum` - for Ethereum personal sign message specification (  [EIP-191](https://eips.ethereum.org/EIPS/eip-191) )
 - `cosmos` - for Cosmos Arbitrary message specificion (  [ADR 036](https://github.com/cosmos/cosmos-sdk/blob/main/docs/architecture/adr-036-arbitrary-signature.md) )
 - `passkeys` - for passkey based authentication ( [Webauthn](https://www.w3.org/TR/webauthn-3) )
-- `curves` - verification of signature over any raw data using any of the supported curves (Ed25519, Secp256k1, Secp256r1) 
+- `curves` - verification of signature over any raw data using any of the supported curves (Ed25519, Secp256k1, Secp256r1)
 - `ed25519` - same as above but only for Ed25519 curve
 
 The following features give you access to additional logic related to better control or additional security
-- `session` - tool and primitives for session keys and message type identification 
-- `replay` - enable replay protection and enforce signed messages to follow a specific format that includes nonces 
-- `std` - whether to enable native Rust std library 
+
+- `session` - tool and primitives for session keys and message type identification
+- `replay` - enable replay protection and enforce signed messages to follow a specific format that includes nonces
+- `std` - whether to enable native Rust std library
 
 The following features enable or disable inner primitives to ether help you out or to reduce the binary size as much as possible
-- `utils` - inner utilities for serialization and preparing them for cryptography 
+
+- `utils` - inner utilities for serialization and preparing them for cryptography
 - `types` - enable minimalistic vm agnostic types ported from `cosmwasm_std` and `cw-utils`
-- `traits` - for importing trait `Verifiable` used internally or `CredentialsWrapper` to customise or simply use the wrapper methods 
+- `traits` - for importing trait `Verifiable` used internally or `CredentialsWrapper` to customise or simply use the wrapper methods
 
 The following credentials are not meant to be specified directly and used only internal purposes 🚫
+
 - `wasm` - common logic for different versions of cosmwasm or it's derivatives
-
-
 
 ## Verification
 
 ### Single Credential
+
 ```rust
 use cosmwasm_std::Binary;
 use smart_acccount_auth::{traits::Verifiable, EvmCredential};
@@ -146,12 +149,12 @@ if cred.is_cosmos_derivable() {
 
 ```
 
-
 # Typescript
 
 ## Installation
 
 Add the library to your project
+
 ```bash
 npm install smart-account-auth
 ```
@@ -161,11 +164,14 @@ npm install smart-account-auth
 ### Basics
 
 Requsting a credemtial is as simple as calling a function with a message to be signed and passing the neccecary signer information
+
 ```typescript
 import { getEthPersonalSignCredential } from 'smart-account-auth';
 const ethCredential = await getEthPersonalSignCredential(window.ethereum, message)
 ```
+
 or
+
 ```typescript
 import { getCosmosArbitraryCredential } from 'smart-account-auth';
 const cosmosCredential = await getCosmosArbitraryCredential(window.keplr, chainId, message)
@@ -197,6 +203,7 @@ const credential = await getPasskeyCredPromise;
 ### Replay Attack Protection
 
 If replay attack protection is enabled on the contract side, the message to be signed must be a json strong of the following format
+
 ```typescript
 type DataToSign = {
     chain_id: string,
@@ -205,12 +212,13 @@ type DataToSign = {
     nonce: string
   }
 ```
-The order of the fields is important (set to alphabetical order) and the nonce must be equal to the current account number
 
+The order of the fields is important (set to alphabetical order) and the nonce must be equal to the current account number
 
 ### Multiple Credentials / Credential Data Wrapper
 
 You can use `CredentialData` object to wrap multiple credentials and efficiently verify them in a single call
+
 ```typescript
 import { CredentialData } from 'smart-account-auth'
 
@@ -225,16 +233,13 @@ const data : CredentialData = {
 ```
 
 ### Meta / Usage
+
 - OpenSource -> Low Funding / Resources -> Contributions are especially needed and welcomed
-- Authors of the library are also its main users. The expirience is iteratively used to improve the SDK by understaning the needs and shifting more and more logic from apps to the lib. 
-- `CosmWasm` retains the status of the primary target and used the most often during feature design stage and for tests. The main reason is being funded through quadrating funding on [DoraHacks](https://dorahacks.io/aez). 
-
-
+- Authors of the library are also its main users. The expirience is iteratively used to improve the SDK by understaning the needs and shifting more and more logic from apps to the lib.
+- `CosmWasm` retains the status of the primary target and used the most often during feature design stage and for tests. The main reason is being funded through quadrating funding on [DoraHacks](https://dorahacks.io/aez).
 
 ## Disclaimer
 
 - 🛠 In-Active development. Breaking changes might occur
 - 👾 Test coverage to be improved and some bugs might occur
 - ⚠️ The project hasn't been audited. Use at your own risk
-
-

--- a/npm/README.md
+++ b/npm/README.md
@@ -10,7 +10,7 @@ npm install smart-account-auth
 
 ### Basics
 
-Requsting a credemtial is as simple as calling a function with a message to be signed and passing the neccecary signer information
+Requesting a credential is as simple as calling a function with a message to be signed and passing the neccecary signer information
 ```typescript
 import { getEthPersonalSignCredential } from 'smart-account-auth';
 const ethCredential = await getEthPersonalSignCredential(window.ethereum, message)
@@ -46,7 +46,7 @@ const credential = await getPasskeyCredPromise;
 
 ### Replay Attack Protection
 
-If replay attack protection is enabled on the contract side, the message to be signed must be a json strong of the following format
+If replay attack protection is enabled on the contract side, the message to be signed must be a json string of the following format
 ```typescript
 type DataToSign = {
     chain_id: string,

--- a/npm/src/credentials/types.ts
+++ b/npm/src/credentials/types.ts
@@ -90,7 +90,7 @@ export interface GetPasskeyParams {
     // enduring that a passkey is stricly a cross-platform  or stricly based on a local platform
     crossPlatform?          :      boolean;
     
-    // parameters for usage of local storage in order to request a specifc credential
+    // parameters for usage of local storage in order to request a specific credential
     // false to disable the usage completely
     localStorage?            :      {
         // name of the local storage key to use: Default: "passkeys"

--- a/packages/auth/Cargo.toml
+++ b/packages/auth/Cargo.toml
@@ -17,7 +17,7 @@ saa-crypto          = { workspace = true }
 saa-common          = { workspace = true }
 saa-schema          = { workspace = true }
 
-# ethabi              = { version = "0.27.0", default-features = false, features = ["serde"] }
+# ethabi              = { version = "0.28.0", default-features = false, features = ["serde"] }
 primitive-types      = { version = "0.12.2", optional = true, default-features = false, features = ["serde"] }
 
 [features]

--- a/packages/auth/Cargo.toml
+++ b/packages/auth/Cargo.toml
@@ -17,7 +17,7 @@ saa-crypto          = { workspace = true }
 saa-common          = { workspace = true }
 saa-schema          = { workspace = true }
 
-# ethabi              = { version = "0.26.0", default-features = false, features = ["serde"] }
+# ethabi              = { version = "0.27.0", default-features = false, features = ["serde"] }
 primitive-types      = { version = "0.12.2", optional = true, default-features = false, features = ["serde"] }
 
 [features]

--- a/packages/bundle/Cargo.toml
+++ b/packages/bundle/Cargo.toml
@@ -6,7 +6,7 @@ authors     = { workspace = true }
 license     = { workspace = true }
 readme      = { workspace = true }
 repository  = { workspace = true }
-version     = "0.26.3"
+version     = "0.27.0"
 
 
 [lib]

--- a/packages/bundle/Cargo.toml
+++ b/packages/bundle/Cargo.toml
@@ -6,7 +6,7 @@ authors     = { workspace = true }
 license     = { workspace = true }
 readme      = { workspace = true }
 repository  = { workspace = true }
-version     = "0.27.0"
+version     = "0.28.0"
 
 
 [lib]

--- a/packages/common/Cargo.toml
+++ b/packages/common/Cargo.toml
@@ -13,8 +13,8 @@ saa-schema          = { workspace = true }
 thiserror           = { workspace = true }
 
 
-cosmwasm-std        = { version = "2.2.2",  optional = true }
-cosmwasm-std-v1     = { version = "1.5.11", optional = true, package = "cosmwasm-std" }
+cosmwasm-std        = { version = "3.0.2",  optional = true }
+cosmwasm-std-v1     = { version = "3.0.2", optional = true, package = "cosmwasm-std" }
 secretwasm-std      = { version = "1.1.11", optional = true, package = "secret-cosmwasm-std" }
 ink                 = { version = "5.1.1", optional = true, default-features = false }
 scale-info          = { workspace = true, optional = true }

--- a/packages/macros-proto/core/Cargo.toml
+++ b/packages/macros-proto/core/Cargo.toml
@@ -5,7 +5,7 @@ edition     = { workspace = true }
 authors     = { workspace = true }
 license     = { workspace = true }
 repository  = { workspace = true }
-version     = "0.26.0"
+version     = "0.27.0"
 
 [lib]
 proc-macro = true

--- a/packages/macros-proto/core/Cargo.toml
+++ b/packages/macros-proto/core/Cargo.toml
@@ -5,7 +5,7 @@ edition     = { workspace = true }
 authors     = { workspace = true }
 license     = { workspace = true }
 repository  = { workspace = true }
-version     = "0.27.0"
+version     = "0.28.0"
 
 [lib]
 proc-macro = true

--- a/packages/macros-proto/core/src/lib.rs
+++ b/packages/macros-proto/core/src/lib.rs
@@ -102,7 +102,7 @@ fn saa_error_impl(input: DeriveInput, options: Options) -> syn::Result<DeriveInp
     let crate_path = &options.crate_path;
     let error_path: syn::Path = syn::parse_quote!(#crate_path::thiserror::Error);
     let mut stream = quote! {
-        #[derive(PartialEq, Debug, #error_path)]
+        #[derive( Debug, #error_path)]
     };
     match &input.data {
         syn::Data::Enum(_) => {},

--- a/packages/macros-proto/solana/Cargo.toml
+++ b/packages/macros-proto/solana/Cargo.toml
@@ -5,7 +5,7 @@ edition     = { workspace = true }
 authors     = { workspace = true }
 license     = { workspace = true }
 repository  = { workspace = true }
-version     = "0.27.0"
+version     = "0.28.0"
 
 
 [lib]

--- a/packages/macros-proto/solana/Cargo.toml
+++ b/packages/macros-proto/solana/Cargo.toml
@@ -5,7 +5,7 @@ edition     = { workspace = true }
 authors     = { workspace = true }
 license     = { workspace = true }
 repository  = { workspace = true }
-version     = "0.26.0"
+version     = "0.27.0"
 
 
 [lib]

--- a/packages/macros-proto/substrate/Cargo.toml
+++ b/packages/macros-proto/substrate/Cargo.toml
@@ -5,7 +5,7 @@ edition     = { workspace = true }
 authors     = { workspace = true }
 license     = { workspace = true }
 repository  = { workspace = true }
-version     = "0.27.0"
+version     = "0.28.0"
 
 
 [lib]

--- a/packages/macros-proto/substrate/Cargo.toml
+++ b/packages/macros-proto/substrate/Cargo.toml
@@ -5,7 +5,7 @@ edition     = { workspace = true }
 authors     = { workspace = true }
 license     = { workspace = true }
 repository  = { workspace = true }
-version     = "0.26.0"
+version     = "0.27.0"
 
 
 [lib]

--- a/packages/macros-proto/wasm/Cargo.toml
+++ b/packages/macros-proto/wasm/Cargo.toml
@@ -5,7 +5,7 @@ edition     = { workspace = true }
 authors     = { workspace = true }
 license     = { workspace = true }
 repository  = { workspace = true }
-version     = "0.26.0"
+version     = "0.27.0"
 
 [lib]
 proc-macro = true

--- a/packages/macros-proto/wasm/Cargo.toml
+++ b/packages/macros-proto/wasm/Cargo.toml
@@ -5,7 +5,7 @@ edition     = { workspace = true }
 authors     = { workspace = true }
 license     = { workspace = true }
 repository  = { workspace = true }
-version     = "0.27.0"
+version     = "0.28.0"
 
 [lib]
 proc-macro = true

--- a/packages/schema/Cargo.toml
+++ b/packages/schema/Cargo.toml
@@ -5,7 +5,7 @@ edition             = { workspace = true }
 authors             = { workspace = true }
 license             = { workspace = true }
 repository          = { workspace = true }
-version             = "0.27.0"
+version             = "0.28.0"
 
 [dependencies]
 saa-proto-core      = { workspace = true  }

--- a/packages/schema/Cargo.toml
+++ b/packages/schema/Cargo.toml
@@ -5,7 +5,7 @@ edition             = { workspace = true }
 authors             = { workspace = true }
 license             = { workspace = true }
 repository          = { workspace = true }
-version             = "0.26.0"
+version             = "0.27.0"
 
 [dependencies]
 saa-proto-core      = { workspace = true  }

--- a/packages/tests/Cargo.toml
+++ b/packages/tests/Cargo.toml
@@ -18,7 +18,7 @@ strum_macros        = { workspace = true }
 strum               = { workspace = true }
 
 serde_json          = { version = "1.0.140" }
-cosmwasm-std        = { version = "2.2.2", default-features = false }
+cosmwasm-std        = { version = "3.0.2", default-features = false }
 base64-url          = { version = "3.0.0", default-features = false }
 hex                 = { version = "0.4.3", default-features = false }
 cosmwasm-schema     = { workspace = true }


### PR DESCRIPTION
### **User description**
- bumps to lates cw version (v3.0.2)
- small QOL bumps to README

## Testing Notes
- `cargo test` works 
- `cargo package` errors: `error: the package 'smart-account-auth' does not contain this feature: traits`


Opening as draft as have not dove deep into resolving, needed a version compatible with v3 for improting as dep in [bs-accounts](https://github.com/permissionlessweb/bs-accounts)

## Summary by Sourcery

Upgrade to CosmWasm v3 and release v0.28.0 with dependency version bumps, macro cleanup, and README enhancements

Enhancements:
- Upgrade CosmWasm dependencies (cosmwasm-schema, cosmwasm-crypto, cosmwasm-std) to v3.0.2 across the workspace
- Bump workspace package version from 0.26.x to 0.28.0 for all crates
- Refactor macro implementation to remove unintended PartialEq derive
- Revise README structure and formatting with detailed tables for credentials, environments, and feature flags


___

### **PR Type**
Enhancement


___

### **Description**
- Upgrade CosmWasm dependencies to v3.0.2

- Bump all workspace packages to v0.28.0

- Remove PartialEq derive from error macro

- Improve README with formatted tables and documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CosmWasm v1/v2"] --> B["CosmWasm v3.0.2"]
  C["Package v0.26.x"] --> D["Package v0.28.0"]
  E["Error Macro"] --> F["Remove PartialEq"]
  G["README"] --> H["Formatted Tables"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>Cargo.toml</strong><dd><code>Update workspace dependencies to CosmWasm v3.0.2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+17/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong><dd><code>Update CosmWasm std dependencies to v3.0.2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-3bd558930555f62814468986d8b39ef8b865ce0dd9cf1b8ad113ee0644425957">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong><dd><code>Update test dependencies to CosmWasm v3.0.2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-fe444bd5d52c716f2b80e83faa27998ba022b9ffb8d11f3155be89b2cbf79144">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Bump version to 0.28.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong><dd><code>Bump bundle package version to 0.28.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-5195a2d48cb4d3faa64d0bcc27d2c4f322ffd62ffe5abe88383730bc5a6c317d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong><dd><code>Bump macro core version to 0.28.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-ecc423f4234abb996d6df14f4d7c3e0b87f5a3a06d5f70bb2712773eb063a681">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong><dd><code>Bump macro solana version to 0.28.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-5a5bef727feb2357af2b1e78d9182ef2397fbd4b99d74e142ce0c56a9c412481">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong><dd><code>Bump macro substrate version to 0.28.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-78e6c3ced3bb25064b583b91c7eeaaad7da67eb0918f7c339b76a2e462d45833">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong><dd><code>Bump macro wasm version to 0.28.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-7dca1ca955d773e616f564b40b67107ce43e9ea551e2382adc361417d4b827fa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong><dd><code>Bump schema package version to 0.28.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-675c204a9c0ab09fda75d13362318bba85db3493f6378c24a2e3fcfeb293ec15">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Improve documentation with formatted tables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+73/-49</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>lib.rs</strong><dd><code>Remove PartialEq from error macro derive</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-545b4caec1dcb928a12e8ab60000b50a4b0cd820e6c7bd29b88cf7e54f2358fa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Cargo.toml</strong><dd><code>Update commented ethabi version reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-d525e165da806589b0d9dd03731706d33a3826cb4774dc0ab58665916293c56d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Upgrade dependencies to support CosmWasm v3 and enhance documentation for clarity and completeness.
> 
>   - **Dependencies**:
>     - Upgrade `cosmwasm-core`, `cosmwasm-crypto`, `cosmwasm-derive`, `cosmwasm-schema`, and `cosmwasm-std` to v3.0.2 in `Cargo.lock` and `Cargo.toml`.
>     - Update `ark-*` dependencies to v0.5.0 in `Cargo.lock`.
>     - Bump `saa-*` package versions to 0.28.0 in `Cargo.toml` and `Cargo.lock`.
>   - **Documentation**:
>     - Revise `README.md` with improved formatting and added tables for supported credentials, VM support, and feature flags.
>     - Update `CHANGELOG.md` to reflect version 0.28.0 changes.
>   - **Misc**:
>     - Fix `saa_error_impl` in `lib.rs` to remove `PartialEq` derive for enums.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=MegaRockLabs%2Fsmart-account-auth&utm_source=github&utm_medium=referral)<sup> for 109c42944fb5bae71107ae6171ff5706c441fc02. You can [customize](https://app.ellipsis.dev/MegaRockLabs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN --> 
 

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR upgrades CosmWasm dependencies to v3.0.2, bumps all workspace packages to version 0.28.0, removes PartialEq derive from error macro, and improves the README with formatted tables and documentation.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Auth
    participant Credential
    participant ReplayProtection

    Client->>Auth: Request Credential Verification
    Auth->>Credential: verify()
    Note over Credential: New unified verify method<br/>Returns CredentialInfo object

    alt Replay Protection Enabled
        Credential->>ReplayProtection: Check Nonce
        ReplayProtection-->>Credential: Validate No Replay
    end

    alt Multiple Credentials
        Auth->>Credential: with_native()
        Note over Credential: Returns copy instead<br/>of modifying in place
    end

    Credential-->>Auth: Return CredentialInfo
    Note over Auth: Optional address field<br/>for specific credentials
    Auth-->>Client: Verification Result
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed>CHANGELOG.md</a></td><td>Bump version to 0.28.0 and document changes.</td></tr>
<tr><td><a href=https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542>Cargo.toml</a></td><td>Update workspace package version to 0.28.0 and upgrade CosmWasm dependencies to v3.0.2.</td></tr>
<tr><td><a href=https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5>README.md</a></td><td>Enhance documentation with formatted tables and improved clarity.</td></tr>
<tr><td><a href=https://github.com/MegaRockLabs/smart-account-auth/pull/11/files#diff-545b4caec1dcb928a12e8ab60000b50a4b0cd820e6c7bd29b88cf7e54f2358fa>packages/macros-proto/core/src/lib.rs</a></td><td>Remove PartialEq derive from error macro.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.md`, `.toml`, `.ts`, `.rs`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end --> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request upgrades CosmWasm dependencies to v3.0.2 and bumps workspace packages to version 0.28.0, ensuring consistency across modules. The changes include extensive library version updates in Cargo.lock, refinements to error macro implementation, and enhanced documentation in README and CHANGELOG files. These updates aim to improve compatibility, stability, and code clarity while paving the way for better performance.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 5
-->
</div>